### PR TITLE
Fix wheel publishing workflow: remove cibuildwheel for pure-Python builds (v4.0.1 release)

### DIFF
--- a/.github/workflows/upload_wheels_to_pypi.yml
+++ b/.github/workflows/upload_wheels_to_pypi.yml
@@ -15,13 +15,11 @@ concurrency:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Build wheel (pure Python)
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -32,23 +30,17 @@ jobs:
 
       - name: Install build tools
         run: |
-          python -m pip install -U pip setuptools wheel cibuildwheel
+          python -m pip install -U pip setuptools wheel build
 
-      - name: Build wheels
-        env:
-          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
-          CIBW_SKIP: "pp* *musllinux*"
-          CIBW_ARCHS_LINUX: "auto"
-          CIBW_ARCHS_MACOS: "x86_64 arm64"
-          CIBW_TEST_SKIP: "*"
+      - name: Build wheel
         run: |
-          python -m cibuildwheel --output-dir wheelhouse
+          python -m build --wheel --outdir dist
 
-      - name: Upload wheels artifact
+      - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}
-          path: wheelhouse/*.whl
+          name: wheel
+          path: dist/*.whl
 
   build_sdist:
     name: Build source distribution
@@ -66,7 +58,7 @@ jobs:
           python -m pip install -U pip build
 
       - name: Build sdist
-        run: python -m build --sdist
+        run: python -m build --sdist --outdir dist
 
       - name: Upload sdist artifact
         uses: actions/upload-artifact@v4
@@ -96,7 +88,7 @@ jobs:
           find dist -type f -name "*.tar.gz" -exec cp {} release/ \;
 
       # -------------------------
-      # 1. OIDC TRUSTED PUBLISHING (PRIMARY)
+      # OIDC TRUSTED PUBLISHING (PRIMARY)
       # -------------------------
       - name: Publish to PyPI (OIDC Trusted Publishing)
         id: pypi-oidc
@@ -106,7 +98,7 @@ jobs:
           packages-dir: release/
 
       # -------------------------
-      # 2. FALLBACK TOKEN PUBLISHING (LEGACY SAFETY NET)
+      # FALLBACK TOKEN PUBLISHING (LEGACY SAFETY NET)
       # -------------------------
       - name: Publish to PyPI (Token fallback)
         if: steps.pypi-oidc.outcome == 'failure'


### PR DESCRIPTION
## Summary

This PR fixes the CI failure in the PyPI publishing workflow caused by misuse of `cibuildwheel` for a pure-Python package.

The project does not contain compiled extensions, so `cibuildwheel` is unnecessary and incorrectly blocking the build with:

> cibuildwheel: Build failed because a pure Python wheel was generated

## Changes

### Removed
- `cibuildwheel` usage across all OS builds
- Cross-compilation wheel strategy (not required for pure Python distributions)

### Replaced with
- Standard `python -m build` for both:
  - source distribution (sdist)
  - wheel (pure Python wheel)

### Benefits
- Fixes CI failure on Windows/macOS/Linux
- Simplifies build pipeline
- Faster and more reliable releases
- Aligns with Python packaging best practices for pure-Python projects

## Notes

- Wheels remain fully cross-platform (`py3-none-any`)
- No functional change to the package
- Compatible with PyPI trusted publishing workflow (OIDC)

## Verification

- [x] Local build succeeds (`python -m build`)
- [x] All CI jobs pass
- [x] Wheel installs correctly on all platforms
- [x] v4.0.1 artifacts validated